### PR TITLE
Remove use of Go routines

### DIFF
--- a/internal/models/album/response.go
+++ b/internal/models/album/response.go
@@ -3,7 +3,6 @@ package album
 import (
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/ghoshRitesh12/brooktube/internal/constants"
 	"github.com/ghoshRitesh12/brooktube/internal/models"
@@ -27,9 +26,7 @@ type ScrapedData struct {
 }
 
 // scrapes and sets basic info of the album
-func (album *ScrapedData) ScrapeAndSetBasicInfo(wg *sync.WaitGroup, header *apiRespHeader, background *models.Thumbnail) {
-	defer wg.Done()
-
+func (album *ScrapedData) ScrapeAndSetBasicInfo(header *apiRespHeader, background *models.Thumbnail) {
 	headerRenderer := header.MusicResponsiveHeaderRenderer
 
 	album.Title = headerRenderer.Title.Runs.GetText()
@@ -71,9 +68,7 @@ type (
 	Tracks []Track
 )
 
-func (tracks *Tracks) ScrapeAndSet(wg *sync.WaitGroup, contents *[]apiRespSectionContent) {
-	defer wg.Done()
-
+func (tracks *Tracks) ScrapeAndSet(contents *[]apiRespSectionContent) {
 	*tracks = make(Tracks, 0, len(*contents))
 
 	for _, content := range *contents {

--- a/internal/models/artist/response.go
+++ b/internal/models/artist/response.go
@@ -2,7 +2,6 @@ package artist
 
 import (
 	"strings"
-	"sync"
 
 	"github.com/ghoshRitesh12/brooktube/internal/constants"
 	"github.com/ghoshRitesh12/brooktube/internal/models"
@@ -31,12 +30,9 @@ type ScrapedData struct {
 
 // scrapes and sets basic info of the artist
 func (artist *ScrapedData) ScrapeAndSetBasicInfo(
-	wg *sync.WaitGroup,
 	header *apiRespHeader,
 	sections *[]apiRespSectionContent,
 ) {
-	defer wg.Done()
-
 	// for artists
 	if header.MusicImmersiveHeaderRenderer.Title.Runs.GetText() != "" {
 		artist.Info.Name = header.MusicImmersiveHeaderRenderer.Title.Runs.GetText()
@@ -71,9 +67,7 @@ type Songs struct {
 }
 
 // scrapes songs section data and sets it
-func (songs *Songs) ScrapeAndSet(wg *sync.WaitGroup, renderer *APIRespMusicShelfRenderer) {
-	defer wg.Done()
-
+func (songs *Songs) ScrapeAndSet(renderer *APIRespMusicShelfRenderer) {
 	if renderer == nil {
 		return
 	}
@@ -103,9 +97,7 @@ type (
 )
 
 // scrapes albums section data and sets it
-func (albums *Albums) ScrapeAndSet(wg *sync.WaitGroup, renderer *APIRespMusicCarouselShelfRenderer) {
-	defer wg.Done()
-
+func (albums *Albums) ScrapeAndSet(renderer *APIRespMusicCarouselShelfRenderer) {
 	if renderer == nil {
 		return
 	}
@@ -149,9 +141,7 @@ type (
 )
 
 // scrapes singles section data and sets it
-func (singles *Singles) ScrapeAndSet(wg *sync.WaitGroup, renderer *APIRespMusicCarouselShelfRenderer) {
-	defer wg.Done()
-
+func (singles *Singles) ScrapeAndSet(renderer *APIRespMusicCarouselShelfRenderer) {
 	if renderer == nil {
 		return
 	}
@@ -191,9 +181,7 @@ type (
 )
 
 // scrapes videos section data and sets it
-func (videos *Videos) ScrapeAndSet(wg *sync.WaitGroup, renderer *APIRespMusicCarouselShelfRenderer) {
-	defer wg.Done()
-
+func (videos *Videos) ScrapeAndSet(renderer *APIRespMusicCarouselShelfRenderer) {
 	if renderer == nil {
 		return
 	}
@@ -230,9 +218,7 @@ type (
 )
 
 // scrapes featured on section data and sets it
-func (featuredOns *FeaturedOns) ScrapeAndSet(wg *sync.WaitGroup, renderer *APIRespMusicCarouselShelfRenderer) {
-	defer wg.Done()
-
+func (featuredOns *FeaturedOns) ScrapeAndSet(renderer *APIRespMusicCarouselShelfRenderer) {
 	if renderer == nil {
 		return
 	}
@@ -266,9 +252,7 @@ type (
 )
 
 // scrapes alike artists section data and sets it
-func (alikeArtists *AlikeArtists) ScrapeAndSet(wg *sync.WaitGroup, renderer *APIRespMusicCarouselShelfRenderer) {
-	defer wg.Done()
-
+func (alikeArtists *AlikeArtists) ScrapeAndSet(renderer *APIRespMusicCarouselShelfRenderer) {
 	if renderer == nil {
 		return
 	}
@@ -319,9 +303,7 @@ type (
 )
 
 // scrapes alike artists section data and sets it
-func (playlists *Playlists) ScrapeAndSet(wg *sync.WaitGroup, renderer *APIRespMusicCarouselShelfRenderer) {
-	defer wg.Done()
-
+func (playlists *Playlists) ScrapeAndSet(renderer *APIRespMusicCarouselShelfRenderer) {
 	if renderer == nil {
 		return
 	}

--- a/internal/models/playlist/response.go
+++ b/internal/models/playlist/response.go
@@ -2,7 +2,6 @@ package playlist
 
 import (
 	"strings"
-	"sync"
 
 	"github.com/ghoshRitesh12/brooktube/internal/constants"
 	"github.com/ghoshRitesh12/brooktube/internal/models"
@@ -28,9 +27,7 @@ type ScrapedData struct {
 }
 
 // scrapes and sets basic info of the playlist
-func (playlist *ScrapedData) ScrapeAndSetBasicInfo(wg *sync.WaitGroup, header *apiRespHeader, background *models.Thumbnail) {
-	defer wg.Done()
-
+func (playlist *ScrapedData) ScrapeAndSetBasicInfo(header *apiRespHeader, background *models.Thumbnail) {
 	headerRenderer := header.MusicResponsiveHeaderRenderer
 
 	playlist.Title = headerRenderer.Title.Runs.GetText()
@@ -71,11 +68,7 @@ type (
 	Tracks []Track
 )
 
-func (tracks *Tracks) ScrapeAndSet(wg *sync.WaitGroup, contents *[]apiRespSectionContent) {
-	if wg != nil {
-		defer wg.Done()
-	}
-
+func (tracks *Tracks) ScrapeAndSet(contents *[]apiRespSectionContent) {
 	*tracks = make(Tracks, 0, len(*contents))
 
 	for _, content := range *contents {

--- a/internal/parsers/album.go
+++ b/internal/parsers/album.go
@@ -2,7 +2,6 @@ package parsers
 
 import (
 	"strings"
-	"sync"
 
 	"github.com/ghoshRitesh12/brooktube/internal/errors"
 	"github.com/ghoshRitesh12/brooktube/internal/models/album"
@@ -10,7 +9,6 @@ import (
 	"github.com/ghoshRitesh12/brooktube/internal/utils"
 )
 
-const ALBUM_SCRAPE_OPERATIONS int = 2
 const ALBUM_BROWSE_ID_PREFIX string = "MPREb_"
 
 func (p *Scraper) GetAlbum(albumId string) (*album.ScrapedData, error) {
@@ -19,7 +17,6 @@ func (p *Scraper) GetAlbum(albumId string) (*album.ScrapedData, error) {
 	}
 
 	albumBrowseId := ""
-	wg := &sync.WaitGroup{}
 	result := &album.ScrapedData{}
 
 	if strings.HasPrefix(albumId, ALBUM_BROWSE_ID_PREFIX) {
@@ -64,12 +61,8 @@ func (p *Scraper) GetAlbum(albumId string) (*album.ScrapedData, error) {
 		return result, nil
 	}
 
-	wg.Add(ALBUM_SCRAPE_OPERATIONS)
-
-	go result.ScrapeAndSetBasicInfo(wg, &headerContents[0], &data.Background)
-	go result.Tracks.ScrapeAndSet(wg, sections)
-
-	wg.Wait()
+	result.ScrapeAndSetBasicInfo(&headerContents[0], &data.Background)
+	result.Tracks.ScrapeAndSet(sections)
 
 	return result, nil
 }

--- a/internal/parsers/artist.go
+++ b/internal/parsers/artist.go
@@ -1,15 +1,12 @@
 package parsers
 
 import (
-	"sync"
-
 	"github.com/ghoshRitesh12/brooktube/internal/errors"
 	"github.com/ghoshRitesh12/brooktube/internal/models/artist"
 	"github.com/ghoshRitesh12/brooktube/internal/requests"
 )
 
 func (p *Scraper) GetArtist(artistChannelID string) (*artist.ScrapedData, error) {
-	wg := &sync.WaitGroup{}
 	result := &artist.ScrapedData{}
 
 	data, err := requests.FetchArtist(artistChannelID)
@@ -27,8 +24,7 @@ func (p *Scraper) GetArtist(artistChannelID string) (*artist.ScrapedData, error)
 		return nil, errors.ErrArtistContentNotFound
 	}
 
-	wg.Add(1)
-	go result.ScrapeAndSetBasicInfo(wg, &data.Header, &sections)
+	result.ScrapeAndSetBasicInfo(&data.Header, &sections)
 
 	for _, section := range sections {
 		sectionName := artist.SectionName("")
@@ -45,29 +41,25 @@ func (p *Scraper) GetArtist(artistChannelID string) (*artist.ScrapedData, error)
 			)
 		}
 
-		wg.Add(1) // assume a case will match
 		switch sectionName {
 		case artist.SECTION_SONGS:
-			go result.Songs.ScrapeAndSet(wg, &section.MusicShelfRenderer)
+			result.Songs.ScrapeAndSet(&section.MusicShelfRenderer)
 		case artist.SECTION_ALBUMS:
-			go result.Albums.ScrapeAndSet(wg, &section.MusicCarouselShelfRenderer)
+			result.Albums.ScrapeAndSet(&section.MusicCarouselShelfRenderer)
 		case artist.SECTION_SINGLES:
-			go result.Singles.ScrapeAndSet(wg, &section.MusicCarouselShelfRenderer)
+			result.Singles.ScrapeAndSet(&section.MusicCarouselShelfRenderer)
 		case artist.SECTION_VIDEOS:
-			go result.Videos.ScrapeAndSet(wg, &section.MusicCarouselShelfRenderer)
+			result.Videos.ScrapeAndSet(&section.MusicCarouselShelfRenderer)
 		case artist.SECTION_FEATURED_ON:
-			go result.FeaturedOns.ScrapeAndSet(wg, &section.MusicCarouselShelfRenderer)
+			result.FeaturedOns.ScrapeAndSet(&section.MusicCarouselShelfRenderer)
 		case artist.SECTION_ALIKE_ARTISTS:
-			go result.AlikeArtists.ScrapeAndSet(wg, &section.MusicCarouselShelfRenderer)
+			result.AlikeArtists.ScrapeAndSet(&section.MusicCarouselShelfRenderer)
 		case artist.SECTION_PLAYLISTS:
-			go result.Playlists.ScrapeAndSet(wg, &section.MusicCarouselShelfRenderer)
+			result.Playlists.ScrapeAndSet(&section.MusicCarouselShelfRenderer)
 		default:
-			wg.Add(-1) // revert the assumption above the switch
 			continue
 		}
 	}
-
-	wg.Wait()
 
 	return result, nil
 }

--- a/internal/parsers/playlist.go
+++ b/internal/parsers/playlist.go
@@ -2,7 +2,6 @@ package parsers
 
 import (
 	"strings"
-	"sync"
 
 	"github.com/ghoshRitesh12/brooktube/internal/errors"
 	"github.com/ghoshRitesh12/brooktube/internal/models/playlist"
@@ -10,14 +9,12 @@ import (
 )
 
 const PLAYLIST_ID_PREFIX string = "VL"
-const PLAYLIST_SCRAPE_OPERATIONS int = 2
 
 func (p *Scraper) GetPlaylist(playlistId string) (*playlist.ScrapedData, error) {
 	if playlistId == "" {
 		return nil, errors.ErrInvalidPlaylistId
 	}
 
-	wg := &sync.WaitGroup{}
 	result := &playlist.ScrapedData{}
 
 	if !strings.HasPrefix(playlistId, PLAYLIST_ID_PREFIX) {
@@ -60,12 +57,8 @@ func (p *Scraper) GetPlaylist(playlistId string) (*playlist.ScrapedData, error) 
 			Continuations.GetContinuationToken(),
 	)
 
-	wg.Add(PLAYLIST_SCRAPE_OPERATIONS)
-
-	go result.ScrapeAndSetBasicInfo(wg, &headerContents[0], &data.Background)
-	go result.Tracks.ScrapeAndSet(wg, sections)
-
-	wg.Wait()
+	result.ScrapeAndSetBasicInfo(&headerContents[0], &data.Background)
+	result.Tracks.ScrapeAndSet(sections)
 
 	return result, nil
 }
@@ -97,7 +90,7 @@ func (p *Scraper) GetMorePlaylistTracks(playlistId, continuationToken string) (*
 		return tracks, nil
 	}
 
-	tracks.ScrapeAndSet(nil, contents)
+	tracks.ScrapeAndSet(contents)
 
 	return tracks, nil
 }


### PR DESCRIPTION
The functions that were being run as Go routines are short and cpu
bound. Not running them as Go routines simplifies the code, and is
faster.

The wall clock time for the execution of the code in `parsers.GetArtist`
(_after_ requests.FetchArtist) is reduced when not using Go routines.
On my system it dropped from around 20μS to about 5μS.

(@ghoshRitesh12, this is a follow up from my direct message to you on reddit a few days ago saying that I'd take a look at this repo.)